### PR TITLE
Switch to SVG badges for visual consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A composable RESTful JSON+HAL API to DBIx::Class schemas using roles, Web::Machine and Path::Router
 
-[![Build Status](https://secure.travis-ci.org/timbunce/WebAPI-DBIC.png)](http://travis-ci.org/timbunce/WebAPI-DBIC)
-[![Coverage Status](https://coveralls.io/repos/timbunce/WebAPI-DBIC/badge.png)](https://coveralls.io/r/timbunce/WebAPI-DBIC)
+[![Build Status](https://secure.travis-ci.org/timbunce/WebAPI-DBIC.svg)](http://travis-ci.org/timbunce/WebAPI-DBIC)
+[![Coverage Status](https://coveralls.io/repos/timbunce/WebAPI-DBIC/badge.svg)](https://coveralls.io/r/timbunce/WebAPI-DBIC)
 
 # DESCRIPTION
 


### PR DESCRIPTION
A very minor contribution, I'm afraid! But I noticed the badges in the readme were not matched, and switching them to SVG provides a consistent visual style across Coveralls and Travis-CI.